### PR TITLE
Fix out of bound error in piecewise find

### DIFF
--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -984,7 +984,7 @@ pub(crate) fn piecewise_linear_find_index(query_value: f32, mapping: &[f32]) -> 
         Ok(index) => return index as f32,
         Err(upper_index) => upper_index,
     };
-    if upper_index == 0 {
+    if upper_index == 0 || upper_index >= mapping.len() {
         return upper_index as f32;
     }
     let lower_index = upper_index - 1;

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -969,6 +969,23 @@ mod test {
             Stretch(1.7)
         );
     }
+
+    #[test]
+    fn test_piecewise_linear_find_index() {
+        assert_eq!(
+            super::piecewise_linear_find_index(0.4, &[0.1, 0.2, 0.3]),
+            3.
+        );
+        assert_eq!(super::piecewise_linear_find_index(0., &[0.1, 0.2, 0.3]), 0.);
+        assert_eq!(
+            super::piecewise_linear_find_index(0.2, &[0.1, 0.2, 0.3]),
+            1.
+        );
+        assert_eq!(
+            super::piecewise_linear_find_index(0.25, &[0.1, 0.2, 0.3]),
+            1.5
+        );
+    }
 }
 
 pub(crate) fn piecewise_linear_lookup(index: f32, mapping: &[f32]) -> f32 {


### PR DESCRIPTION
Fixes [WAR-1171](https://linear.app/warpdotdev/issue/WAR-1171/crash-when-scrolling-through-fonts)

Binary search could return the index that is larger than the range of the array. This fix puts an additional check to prevent the out-of-bound.call.