### PR TITLE
Make slice bound safe

### DIFF
--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -822,6 +822,10 @@ fn read_number_of_fonts_from_otc_header(header: &[u8]) -> Result<u32, FontLoadin
     Ok((&header[8..]).read_u32::<BigEndian>()?)
 }
 
+fn get_slice_from_start(slice: &[u8], start: usize) -> Result<&[u8], FontLoadingError> {
+    slice.get(start..).ok_or(FontLoadingError::Parse)
+}
+
 // Unpacks an OTC font "in-place".
 fn unpack_otc_font(data: &mut [u8], font_index: u32) -> Result<(), FontLoadingError> {
     if font_index >= read_number_of_fonts_from_otc_header(data)? {
@@ -830,15 +834,12 @@ fn unpack_otc_font(data: &mut [u8], font_index: u32) -> Result<(), FontLoadingEr
 
     let offset_table_pos_pos = 12 + 4 * font_index as usize;
 
-    if offset_table_pos_pos + 4 > data.len() {
-        return Err(FontLoadingError::Parse);
-    }
-
-    let offset_table_pos = (&data[offset_table_pos_pos..]).read_u32::<BigEndian>()? as usize;
+    let offset_table_pos =
+        get_slice_from_start(&data, offset_table_pos_pos)?.read_u32::<BigEndian>()? as usize;
     debug_assert!(utils::SFNT_VERSIONS
         .iter()
         .any(|version| { data[offset_table_pos..(offset_table_pos + 4)] == *version }));
-    let num_tables = (&data[(offset_table_pos + 4)..]).read_u16::<BigEndian>()?;
+    let num_tables = get_slice_from_start(&data, offset_table_pos + 4)?.read_u16::<BigEndian>()?;
 
     // Must copy forward in order to avoid problems with overlapping memory.
     let offset_table_and_table_record_size = 12 + (num_tables as usize) * 16;
@@ -872,40 +873,32 @@ fn font_is_single_otf(header: &[u8]) -> bool {
 
 /// https://developer.apple.com/library/archive/documentation/mac/pdf/MoreMacintoshToolbox.pdf#page=151
 fn unpack_data_fork_font(data: &mut [u8]) -> Result<(), FontLoadingError> {
-    fn get_slice_from_start(slice: &[u8], start: usize) -> Result<&[u8], FontLoadingError> {
-        if start > slice.len() {
-            Err(FontLoadingError::Parse)
-        } else {
-            Ok(&slice[start..])
-        }
-    }
-
     let data_offset = (&data[..]).read_u32::<BigEndian>()? as usize;
-    let map_offset = (get_slice_from_start(&data, 4)?).read_u32::<BigEndian>()? as usize;
+    let map_offset = get_slice_from_start(&data, 4)?.read_u32::<BigEndian>()? as usize;
     let num_types =
-        (get_slice_from_start(&data, map_offset + 28)?).read_u16::<BigEndian>()? as usize + 1;
+        get_slice_from_start(&data, map_offset + 28)?.read_u16::<BigEndian>()? as usize + 1;
 
     let mut font_data_offset = 0;
     let mut font_data_len = 0;
 
-    let type_list_offset = (get_slice_from_start(&data, map_offset + 24)?)
-        .read_u16::<BigEndian>()? as usize
+    let type_list_offset = get_slice_from_start(&data, map_offset + 24)?.read_u16::<BigEndian>()?
+        as usize
         + map_offset;
     for i in 0..num_types {
         let res_type =
-            (get_slice_from_start(&data, map_offset + 30 + i * 8)?).read_u32::<BigEndian>()?;
+            get_slice_from_start(&data, map_offset + 30 + i * 8)?.read_u32::<BigEndian>()?;
 
         if res_type == SFNT_HEX {
-            let ref_list_offset = (get_slice_from_start(&data, map_offset + 30 + i * 8 + 6)?)
+            let ref_list_offset = get_slice_from_start(&data, map_offset + 30 + i * 8 + 6)?
                 .read_u16::<BigEndian>()? as usize;
             let res_data_offset =
-                (get_slice_from_start(&data, type_list_offset + ref_list_offset + 5)?)
+                get_slice_from_start(&data, type_list_offset + ref_list_offset + 5)?
                     .read_u24::<BigEndian>()? as usize;
-            font_data_len = (get_slice_from_start(&data, data_offset + res_data_offset)?)
+            font_data_len = get_slice_from_start(&data, data_offset + res_data_offset)?
                 .read_u32::<BigEndian>()? as usize;
             font_data_offset = data_offset + res_data_offset + 4;
             let sfnt_version =
-                (get_slice_from_start(&data, font_data_offset)?).read_u32::<BigEndian>()?;
+                get_slice_from_start(&data, font_data_offset)?.read_u32::<BigEndian>()?;
 
             // TrueType outline, 'OTTO', 'true', 'typ1'
             if sfnt_version == 0x00010000

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -829,6 +829,11 @@ fn unpack_otc_font(data: &mut [u8], font_index: u32) -> Result<(), FontLoadingEr
     }
 
     let offset_table_pos_pos = 12 + 4 * font_index as usize;
+
+    if offset_table_pos_pos + 4 > data.len() {
+        return Err(FontLoadingError::Parse);
+    }
+
     let offset_table_pos = (&data[offset_table_pos_pos..]).read_u32::<BigEndian>()? as usize;
     debug_assert!(utils::SFNT_VERSIONS
         .iter()
@@ -867,27 +872,40 @@ fn font_is_single_otf(header: &[u8]) -> bool {
 
 /// https://developer.apple.com/library/archive/documentation/mac/pdf/MoreMacintoshToolbox.pdf#page=151
 fn unpack_data_fork_font(data: &mut [u8]) -> Result<(), FontLoadingError> {
+    fn get_slice_from_start(slice: &[u8], start: usize) -> Result<&[u8], FontLoadingError> {
+        if start > slice.len() {
+            Err(FontLoadingError::Parse)
+        } else {
+            Ok(&slice[start..])
+        }
+    }
+
     let data_offset = (&data[..]).read_u32::<BigEndian>()? as usize;
-    let map_offset = (&data[4..]).read_u32::<BigEndian>()? as usize;
-    let num_types = (&data[map_offset + 28..]).read_u16::<BigEndian>()? as usize + 1;
+    let map_offset = (get_slice_from_start(&data, 4)?).read_u32::<BigEndian>()? as usize;
+    let num_types =
+        (get_slice_from_start(&data, map_offset + 28)?).read_u16::<BigEndian>()? as usize + 1;
 
     let mut font_data_offset = 0;
     let mut font_data_len = 0;
 
-    let type_list_offset =
-        (&data[map_offset + 24..]).read_u16::<BigEndian>()? as usize + map_offset;
+    let type_list_offset = (get_slice_from_start(&data, map_offset + 24)?)
+        .read_u16::<BigEndian>()? as usize
+        + map_offset;
     for i in 0..num_types {
-        let res_type = (&data[map_offset + 30 + i * 8..]).read_u32::<BigEndian>()?;
+        let res_type =
+            (get_slice_from_start(&data, map_offset + 30 + i * 8)?).read_u32::<BigEndian>()?;
 
         if res_type == SFNT_HEX {
-            let ref_list_offset =
-                (&data[map_offset + 30 + i * 8 + 6..]).read_u16::<BigEndian>()? as usize;
+            let ref_list_offset = (get_slice_from_start(&data, map_offset + 30 + i * 8 + 6)?)
+                .read_u16::<BigEndian>()? as usize;
             let res_data_offset =
-                (&data[type_list_offset + ref_list_offset + 5..]).read_u24::<BigEndian>()? as usize;
-            font_data_len =
-                (&data[data_offset + res_data_offset..]).read_u32::<BigEndian>()? as usize;
+                (get_slice_from_start(&data, type_list_offset + ref_list_offset + 5)?)
+                    .read_u24::<BigEndian>()? as usize;
+            font_data_len = (get_slice_from_start(&data, data_offset + res_data_offset)?)
+                .read_u32::<BigEndian>()? as usize;
             font_data_offset = data_offset + res_data_offset + 4;
-            let sfnt_version = (&data[font_data_offset..]).read_u32::<BigEndian>()?;
+            let sfnt_version =
+                (get_slice_from_start(&data, font_data_offset)?).read_u32::<BigEndian>()?;
 
             // TrueType outline, 'OTTO', 'true', 'typ1'
             if sfnt_version == 0x00010000


### PR DESCRIPTION
Fixes WAR-1432

**Info**
This PR does not change how we load the font -- the cause for the panic is probably because users have corrupted / non-standard font header files which do not report accurate length of the font collection. The font-kit library current loads files assuming these length information will be correct and thus when these assumptions turn out to be false, the loading will panic because of the out of bounds error on slicing. 

**Change**
Add type safe slicing which returns an error when index out of bounds rather than panicking.