### PR TITLE
Create function for accessing font-kit interface without loading into memory

### DIFF
--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -66,8 +66,8 @@ pub type NativeFont = CTFont;
 /// A loader that uses Apple's Core Text API to load and rasterize fonts.
 #[derive(Clone)]
 pub struct Font {
-    pub core_text_font: CTFont,
-    pub font_data: FontData,
+    core_text_font: CTFont,
+    font_data: FontData,
 }
 
 impl Font {
@@ -124,6 +124,15 @@ impl Font {
     /// Creates a font from a native API handle.
     pub unsafe fn from_native_font(core_text_font: NativeFont) -> Font {
         Font::from_core_text_font(core_text_font)
+    }
+
+    /// Creates a font object to allow an interface to all the font-kit functions
+    /// without loading it into the memory.
+    pub fn from_ct_font(ct_font: CTFont) -> Font {
+        Font {
+            core_text_font: ct_font,
+            font_data: FontData::Unavailable,
+        }
     }
 
     unsafe fn from_core_text_font(core_text_font: NativeFont) -> Font {
@@ -771,12 +780,9 @@ impl Debug for Font {
     }
 }
 
-/// Describes the font.
 #[derive(Debug, Clone)]
-pub enum FontData {
-    /// No available information
+enum FontData {
     Unavailable,
-    /// From bytes
     Memory(Arc<Vec<u8>>),
 }
 

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -780,7 +780,7 @@ impl Debug for Font {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 enum FontData {
     Unavailable,
     Memory(Arc<Vec<u8>>),

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -66,8 +66,8 @@ pub type NativeFont = CTFont;
 /// A loader that uses Apple's Core Text API to load and rasterize fonts.
 #[derive(Clone)]
 pub struct Font {
-    core_text_font: CTFont,
-    font_data: FontData,
+    pub core_text_font: CTFont,
+    pub font_data: FontData,
 }
 
 impl Font {

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -771,9 +771,12 @@ impl Debug for Font {
     }
 }
 
-#[derive(Clone)]
-enum FontData {
+/// Describes the font.
+#[derive(Debug, Clone)]
+pub enum FontData {
+    /// No available information
     Unavailable,
+    /// From bytes
     Memory(Arc<Vec<u8>>),
 }
 

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -126,8 +126,10 @@ impl Font {
         Font::from_core_text_font(core_text_font)
     }
 
-    /// Creates a font object to allow an interface to all the font-kit functions
-    /// without loading it into the memory.
+    /// This is an edit made by Warp team. We should avoid using the provided font loading functions
+    /// in font-kit as they are extremely memory inefficient. This function instead creates a font
+    /// object with an existing CTFont to allow an interface to all the font-kit functions without
+    /// loading it into the memory.
     pub fn from_ct_font(ct_font: CTFont) -> Font {
         Font {
             core_text_font: ct_font,


### PR DESCRIPTION
This allows us to create a `Font` struct without needing to load the system font file.