### PR TITLE
Add support for rendering glyphs using thin strokes.

### DIFF
--- a/examples/render-glyph.rs
+++ b/examples/render-glyph.rs
@@ -15,7 +15,7 @@ extern crate pathfinder_geometry;
 
 use clap::{App, Arg, ArgGroup, ArgMatches};
 use colored::Colorize;
-use font_kit::canvas::{Canvas, Format, AntialiasingStrategy, RasterizationOptions};
+use font_kit::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
 use font_kit::hinting::HintingOptions;
 use font_kit::source::SystemSource;
 use pathfinder_geometry::transform2d::Transform2F;

--- a/examples/render-glyph.rs
+++ b/examples/render-glyph.rs
@@ -15,7 +15,7 @@ extern crate pathfinder_geometry;
 
 use clap::{App, Arg, ArgGroup, ArgMatches};
 use colored::Colorize;
-use font_kit::canvas::{Canvas, Format, RasterizationOptions};
+use font_kit::canvas::{Canvas, Format, AntialiasingStrategy, RasterizationOptions};
 use font_kit::hinting::HintingOptions;
 use font_kit::source::SystemSource;
 use pathfinder_geometry::transform2d::Transform2F;
@@ -65,6 +65,9 @@ fn get_args() -> ArgMatches<'static> {
         .number_of_values(4);
     let rasterization_mode_group =
         ArgGroup::with_name("rasterization-mode").args(&["grayscale", "bilevel", "subpixel"]);
+    let thin_strokes_arg = Arg::with_name("use_thin_strokes")
+        .help("Use thin strokes when rasterizing glyphs")
+        .long("use_thin_strokes");
     App::new("render-glyph")
         .version("0.1")
         .author("The Pathfinder Project Developers")
@@ -76,6 +79,7 @@ fn get_args() -> ArgMatches<'static> {
         .arg(bilevel_arg)
         .arg(subpixel_arg)
         .group(rasterization_mode_group)
+        .arg(thin_strokes_arg)
         .arg(hinting_arg)
         .arg(transform_arg)
         .get_matches()
@@ -88,12 +92,17 @@ fn main() {
     let character = matches.value_of("GLYPH").unwrap().chars().next().unwrap();
     let size: f32 = matches.value_of("SIZE").unwrap().parse().unwrap();
 
-    let (canvas_format, rasterization_options) = if matches.is_present("bilevel") {
-        (Format::A8, RasterizationOptions::Bilevel)
+    let (canvas_format, antialiasing_strategy) = if matches.is_present("bilevel") {
+        (Format::A8, AntialiasingStrategy::Bilevel)
     } else if matches.is_present("subpixel") {
-        (Format::Rgb24, RasterizationOptions::SubpixelAa)
+        (Format::Rgb24, AntialiasingStrategy::SubpixelAa)
     } else {
-        (Format::A8, RasterizationOptions::GrayscaleAa)
+        (Format::A8, AntialiasingStrategy::GrayscaleAa)
+    };
+
+    let rasterization_options = RasterizationOptions {
+        antialiasing_strategy,
+        use_thin_strokes: matches.is_present("use_thin_strokes"),
     };
 
     let mut transform = Transform2F::default();

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -249,13 +249,24 @@ impl Format {
 
 /// The antialiasing strategy that should be used when rasterizing glyphs.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum RasterizationOptions {
+pub enum AntialiasingStrategy {
     /// "Black-and-white" rendering. Each pixel is either entirely on or off.
     Bilevel,
     /// Grayscale antialiasing. Only one channel is used.
     GrayscaleAa,
     /// Subpixel RGB antialiasing, for LCD screens.
     SubpixelAa,
+}
+
+/// Options to control rasterization.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RasterizationOptions {
+    /// The antialiasing strategy to use when rasterizing glyphs.
+    pub antialiasing_strategy: AntialiasingStrategy,
+
+    /// Whether or not to render glyphs with a thinner stroke.
+    /// Currently only supported for the core_text loader.
+    pub use_thin_strokes: bool,
 }
 
 trait Blit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!     # extern crate font_kit;
 //!     # extern crate pathfinder_geometry;
 //!     #
-//!     use font_kit::canvas::{Canvas, Format, RasterizationOptions};
+//!     use font_kit::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
 //!     use font_kit::family_name::FamilyName;
 //!     use font_kit::hinting::HintingOptions;
 //!     use font_kit::properties::Properties;
@@ -37,7 +37,10 @@
 //!                          32.0,
 //!                          Transform2F::from_translation(Vector2F::new(0.0, 32.0)),
 //!                          HintingOptions::None,
-//!                          RasterizationOptions::GrayscaleAa)
+//!                          RasterizationOptions {
+//!                              antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+//!                              use_thin_strokes: false,
+//!                          })
 //!         .unwrap();
 //!
 //! ## Backends

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -17,7 +17,7 @@ use pathfinder_geometry::transform2d::Transform2F;
 use pathfinder_geometry::vector::Vector2F;
 use std::sync::Arc;
 
-use crate::canvas::{Canvas, RasterizationOptions};
+use crate::canvas::{Canvas, AntialiasingStrategy, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -17,7 +17,7 @@ use pathfinder_geometry::transform2d::Transform2F;
 use pathfinder_geometry::vector::Vector2F;
 use std::sync::Arc;
 
-use crate::canvas::{Canvas, AntialiasingStrategy, RasterizationOptions};
+use crate::canvas::{AntialiasingStrategy, Canvas, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -559,8 +559,9 @@ impl Font {
             AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
                 // FIXME(pcwalton): These shouldn't be handled the same!
                 if rasterization_options.use_thin_strokes {
+                    // Font smoothing produces thicker strokes; turning it off will lead to
+                    // thinner glyphs.
                     core_graphics_context.set_should_smooth_fonts(false);
-                    core_graphics_context.set_font_smoothing_style(16);
                 } else {
                     core_graphics_context.set_should_smooth_fonts(true);
                 }

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -37,7 +37,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::canvas::{Canvas, Format, RasterizationOptions};
+use crate::canvas::{Canvas, Format, AntialiasingStrategy, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -550,16 +550,21 @@ impl Font {
         let core_graphics_size = CGSize::new(canvas.size.x() as f64, canvas.size.y() as f64);
         core_graphics_context.fill_rect(CGRect::new(&CG_ZERO_POINT, &core_graphics_size));
 
-        match rasterization_options {
-            RasterizationOptions::Bilevel => {
+        match rasterization_options.antialiasing_strategy {
+            AntialiasingStrategy::Bilevel => {
                 core_graphics_context.set_allows_font_smoothing(false);
                 core_graphics_context.set_should_smooth_fonts(false);
                 core_graphics_context.set_should_antialias(false);
             }
-            RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
+            AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
                 // FIXME(pcwalton): These shouldn't be handled the same!
+                if rasterization_options.use_thin_strokes {
+                    core_graphics_context.set_should_smooth_fonts(false);
+                    core_graphics_context.set_font_smoothing_style(16);
+                } else {
+                    core_graphics_context.set_should_smooth_fonts(true);
+                }
                 core_graphics_context.set_allows_font_smoothing(true);
-                core_graphics_context.set_should_smooth_fonts(true);
                 core_graphics_context.set_should_antialias(true);
             }
         }

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -37,7 +37,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::canvas::{Canvas, Format, AntialiasingStrategy, RasterizationOptions};
+use crate::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -45,7 +45,7 @@ use winapi::um::dwrite::DWRITE_READING_DIRECTION;
 use winapi::um::dwrite::DWRITE_READING_DIRECTION_LEFT_TO_RIGHT;
 use winapi::um::fileapi;
 
-use crate::canvas::{Canvas, Format, RasterizationOptions};
+use crate::canvas::{Canvas, Format, AntialiasingStrategy};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -463,9 +463,9 @@ impl Font {
             rasterization_options,
         )?;
 
-        let texture_type = match rasterization_options {
-            RasterizationOptions::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
-            RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
+        let texture_type = match rasterization_options.antialiasing_strategy {
+            AntialiasingStrategy::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
+            AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
                 DWRITE_TEXTURE_CLEARTYPE_3x1
             }
         };
@@ -510,8 +510,8 @@ impl Font {
         )?;
 
         let texture_type = match rasterization_options {
-            RasterizationOptions::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
-            RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
+            AntialiasingStrategy::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
+            AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
                 DWRITE_TEXTURE_CLEARTYPE_3x1
             }
         };
@@ -598,8 +598,8 @@ impl Font {
             };
 
             let rendering_mode = match rasterization_options {
-                RasterizationOptions::Bilevel => DWRITE_RENDERING_MODE_ALIASED,
-                RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
+                AntialiasingStrategy::Bilevel => DWRITE_RENDERING_MODE_ALIASED,
+                AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
                     DWRITE_RENDERING_MODE_NATURAL
                 }
             };

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -45,7 +45,7 @@ use winapi::um::dwrite::DWRITE_READING_DIRECTION;
 use winapi::um::dwrite::DWRITE_READING_DIRECTION_LEFT_TO_RIGHT;
 use winapi::um::fileapi;
 
-use crate::canvas::{Canvas, Format, AntialiasingStrategy};
+use crate::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -509,7 +509,7 @@ impl Font {
             rasterization_options,
         )?;
 
-        let texture_type = match rasterization_options {
+        let texture_type = match rasterization_options.antialiasing_strategy {
             AntialiasingStrategy::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
             AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
                 DWRITE_TEXTURE_CLEARTYPE_3x1
@@ -597,7 +597,7 @@ impl Font {
                 bidiLevel: 0,
             };
 
-            let rendering_mode = match rasterization_options {
+            let rendering_mode = match rasterization_options.antialiasing_strategy {
                 AntialiasingStrategy::Bilevel => DWRITE_RENDERING_MODE_ALIASED,
                 AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
                     DWRITE_RENDERING_MODE_NATURAL

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -42,7 +42,7 @@ use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
-use crate::canvas::{Canvas, Format, RasterizationOptions};
+use crate::canvas::{Canvas, Format, AntialiasingStrategy};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -430,7 +430,7 @@ impl Font {
         S: OutlineSink,
     {
         unsafe {
-            let rasterization_options = RasterizationOptions::GrayscaleAa;
+            let rasterization_options = AntialiasingStrategy::GrayscaleAa;
             let load_flags = self
                 .hinting_and_rasterization_options_to_load_flags(hinting, rasterization_options);
 
@@ -765,7 +765,7 @@ impl Font {
         point_size: f32,
         transform: Transform2F,
         hinting_options: HintingOptions,
-        rasterization_options: RasterizationOptions,
+        rasterization_options: AntialiasingStrategy,
     ) -> Result<RectI, GlyphLoadingError> {
         <Self as Loader>::raster_bounds(
             self,
@@ -793,7 +793,7 @@ impl Font {
         point_size: f32,
         transform: Transform2F,
         hinting_options: HintingOptions,
-        rasterization_options: RasterizationOptions,
+        rasterization_options: AntialiasingStrategy,
     ) -> Result<(), GlyphLoadingError> {
         // TODO(pcwalton): This is woefully incomplete. See WebRender's code for a more complete
         // implementation.
@@ -873,19 +873,19 @@ impl Font {
     fn hinting_and_rasterization_options_to_load_flags(
         &self,
         hinting: HintingOptions,
-        rasterization: RasterizationOptions,
+        rasterization: AntialiasingStrategy,
     ) -> u32 {
         let mut options = match (hinting, rasterization) {
-            (HintingOptions::VerticalSubpixel(_), _) | (_, RasterizationOptions::SubpixelAa) => {
+            (HintingOptions::VerticalSubpixel(_), _) | (_, AntialiasingStrategy::SubpixelAa) => {
                 FT_LOAD_TARGET_LCD
             }
             (HintingOptions::None, _) => FT_LOAD_TARGET_NORMAL | FT_LOAD_NO_HINTING,
-            (HintingOptions::Vertical(_), RasterizationOptions::Bilevel)
-            | (HintingOptions::Full(_), RasterizationOptions::Bilevel) => FT_LOAD_TARGET_MONO,
+            (HintingOptions::Vertical(_), AntialiasingStrategy::Bilevel)
+            | (HintingOptions::Full(_), AntialiasingStrategy::Bilevel) => FT_LOAD_TARGET_MONO,
             (HintingOptions::Vertical(_), _) => FT_LOAD_TARGET_LIGHT,
             (HintingOptions::Full(_), _) => FT_LOAD_TARGET_NORMAL,
         };
-        if rasterization == RasterizationOptions::Bilevel {
+        if rasterization == AntialiasingStrategy::Bilevel {
             options |= FT_LOAD_MONOCHROME
         }
         options
@@ -1112,7 +1112,7 @@ impl Loader for Font {
         point_size: f32,
         transform: Transform2F,
         hinting_options: HintingOptions,
-        rasterization_options: RasterizationOptions,
+        rasterization_options: AntialiasingStrategy,
     ) -> Result<(), GlyphLoadingError> {
         self.rasterize_glyph(
             canvas,

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -42,7 +42,7 @@ use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
-use crate::canvas::{Canvas, Format, AntialiasingStrategy};
+use crate::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -430,7 +430,10 @@ impl Font {
         S: OutlineSink,
     {
         unsafe {
-            let rasterization_options = AntialiasingStrategy::GrayscaleAa;
+            let rasterization_options = RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+                use_thin_strokes: false,
+            };
             let load_flags = self
                 .hinting_and_rasterization_options_to_load_flags(hinting, rasterization_options);
 
@@ -765,7 +768,7 @@ impl Font {
         point_size: f32,
         transform: Transform2F,
         hinting_options: HintingOptions,
-        rasterization_options: AntialiasingStrategy,
+        rasterization_options: RasterizationOptions,
     ) -> Result<RectI, GlyphLoadingError> {
         <Self as Loader>::raster_bounds(
             self,
@@ -793,7 +796,7 @@ impl Font {
         point_size: f32,
         transform: Transform2F,
         hinting_options: HintingOptions,
-        rasterization_options: AntialiasingStrategy,
+        rasterization_options: RasterizationOptions,
     ) -> Result<(), GlyphLoadingError> {
         // TODO(pcwalton): This is woefully incomplete. See WebRender's code for a more complete
         // implementation.
@@ -873,9 +876,9 @@ impl Font {
     fn hinting_and_rasterization_options_to_load_flags(
         &self,
         hinting: HintingOptions,
-        rasterization: AntialiasingStrategy,
+        rasterization: RasterizationOptions,
     ) -> u32 {
-        let mut options = match (hinting, rasterization) {
+        let mut options = match (hinting, rasterization.antialiasing_strategy) {
             (HintingOptions::VerticalSubpixel(_), _) | (_, AntialiasingStrategy::SubpixelAa) => {
                 FT_LOAD_TARGET_LCD
             }
@@ -885,7 +888,7 @@ impl Font {
             (HintingOptions::Vertical(_), _) => FT_LOAD_TARGET_LIGHT,
             (HintingOptions::Full(_), _) => FT_LOAD_TARGET_NORMAL,
         };
-        if rasterization == AntialiasingStrategy::Bilevel {
+        if rasterization.antialiasing_strategy == AntialiasingStrategy::Bilevel {
             options |= FT_LOAD_MONOCHROME
         }
         options
@@ -1112,7 +1115,7 @@ impl Loader for Font {
         point_size: f32,
         transform: Transform2F,
         hinting_options: HintingOptions,
-        rasterization_options: AntialiasingStrategy,
+        rasterization_options: RasterizationOptions,
     ) -> Result<(), GlyphLoadingError> {
         self.rasterize_glyph(
             canvas,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,7 +10,7 @@
 
 // General tests.
 
-use font_kit::canvas::{Canvas, Format, AntialiasingStrategy, RasterizationOptions};
+use font_kit::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
 use font_kit::family_name::FamilyName;
 use font_kit::file_type::FileType;
 use font_kit::font::Font;
@@ -453,7 +453,10 @@ pub fn get_glyph_raster_bounds() {
     let transform = Transform2F::default();
     let size = 32.0;
     let hinting_options = HintingOptions::None;
-    let rasterization_options = RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false };
+    let rasterization_options = RasterizationOptions {
+        antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+        use_thin_strokes: false,
+    };
     #[cfg(all(not(target_family = "windows")))]
     let expected_rect = RectI::new(Vector2I::new(1, -20), Vector2I::new(14, 21));
     #[cfg(target_family = "windows")]
@@ -665,7 +668,10 @@ pub fn rasterize_glyph_with_grayscale_aa() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -675,7 +681,10 @@ pub fn rasterize_glyph_with_grayscale_aa() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+        RasterizationOptions {
+            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+            use_thin_strokes: false,
+        },
     )
     .unwrap();
     check_L_shape(&canvas);
@@ -697,7 +706,10 @@ pub fn rasterize_glyph_bilevel() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::Bilevel,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -707,7 +719,10 @@ pub fn rasterize_glyph_bilevel() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
+        RasterizationOptions {
+            antialiasing_strategy: AntialiasingStrategy::Bilevel,
+            use_thin_strokes: false,
+        },
     )
     .unwrap();
     assert!(canvas
@@ -733,7 +748,10 @@ pub fn rasterize_glyph_bilevel_offset() {
             size,
             Transform2F::from_translation(Vector2F::new(30.0, 100.0)),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::Bilevel,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -743,7 +761,10 @@ pub fn rasterize_glyph_bilevel_offset() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32() + Vector2F::new(30.0, 100.0)),
         HintingOptions::None,
-        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
+        RasterizationOptions {
+            antialiasing_strategy: AntialiasingStrategy::Bilevel,
+            use_thin_strokes: false,
+        },
     )
     .unwrap();
 
@@ -776,7 +797,10 @@ pub fn rasterize_glyph_with_full_hinting() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::Bilevel,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     let origin = -raster_rect.origin().to_f32();
@@ -787,7 +811,10 @@ pub fn rasterize_glyph_with_full_hinting() {
         size,
         Transform2F::from_translation(origin),
         HintingOptions::Full(size),
-        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+        RasterizationOptions {
+            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+            use_thin_strokes: false,
+        },
     )
     .unwrap();
     check_L_shape(&canvas);
@@ -825,7 +852,10 @@ pub fn rasterize_glyph() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -835,7 +865,10 @@ pub fn rasterize_glyph() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+        RasterizationOptions {
+            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+            use_thin_strokes: false,
+        },
     )
     .unwrap();
     check_curly_shape(&canvas);
@@ -855,7 +888,10 @@ pub fn rasterize_empty_glyph() {
         16.0,
         Transform2F::default(),
         HintingOptions::None,
-        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+        RasterizationOptions {
+            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+            use_thin_strokes: false,
+        },
     )
     .unwrap();
 }
@@ -874,7 +910,10 @@ pub fn rasterize_empty_glyph_on_empty_canvas() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -884,7 +923,10 @@ pub fn rasterize_empty_glyph_on_empty_canvas() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
+        RasterizationOptions {
+            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
+            use_thin_strokes: false,
+        },
     )
     .unwrap();
 }
@@ -905,7 +947,10 @@ pub fn font_transform() {
             size,
             Transform2F::from_translation(Vector2F::splat(8.0)),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::Bilevel,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     let raster_rect2 = font
@@ -914,7 +959,10 @@ pub fn font_transform() {
             size,
             Transform2F::row_major(3.0, 0.0, 0.0, 3.0, 8.0, 8.0),
             HintingOptions::None,
-            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
+            RasterizationOptions {
+                antialiasing_strategy: AntialiasingStrategy::Bilevel,
+                use_thin_strokes: false,
+            },
         )
         .unwrap();
     assert!((raster_rect2.width() - raster_rect.width() * 3).abs() <= 3);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,7 +10,7 @@
 
 // General tests.
 
-use font_kit::canvas::{Canvas, Format, RasterizationOptions};
+use font_kit::canvas::{Canvas, Format, AntialiasingStrategy, RasterizationOptions};
 use font_kit::family_name::FamilyName;
 use font_kit::file_type::FileType;
 use font_kit::font::Font;
@@ -453,7 +453,7 @@ pub fn get_glyph_raster_bounds() {
     let transform = Transform2F::default();
     let size = 32.0;
     let hinting_options = HintingOptions::None;
-    let rasterization_options = RasterizationOptions::GrayscaleAa;
+    let rasterization_options = RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false };
     #[cfg(all(not(target_family = "windows")))]
     let expected_rect = RectI::new(Vector2I::new(1, -20), Vector2I::new(14, 21));
     #[cfg(target_family = "windows")]
@@ -665,7 +665,7 @@ pub fn rasterize_glyph_with_grayscale_aa() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions::GrayscaleAa,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -675,7 +675,7 @@ pub fn rasterize_glyph_with_grayscale_aa() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions::GrayscaleAa,
+        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
     )
     .unwrap();
     check_L_shape(&canvas);
@@ -697,7 +697,7 @@ pub fn rasterize_glyph_bilevel() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions::Bilevel,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -707,7 +707,7 @@ pub fn rasterize_glyph_bilevel() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions::Bilevel,
+        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
     )
     .unwrap();
     assert!(canvas
@@ -733,7 +733,7 @@ pub fn rasterize_glyph_bilevel_offset() {
             size,
             Transform2F::from_translation(Vector2F::new(30.0, 100.0)),
             HintingOptions::None,
-            RasterizationOptions::Bilevel,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -743,7 +743,7 @@ pub fn rasterize_glyph_bilevel_offset() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32() + Vector2F::new(30.0, 100.0)),
         HintingOptions::None,
-        RasterizationOptions::Bilevel,
+        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
     )
     .unwrap();
 
@@ -776,7 +776,7 @@ pub fn rasterize_glyph_with_full_hinting() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions::Bilevel,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
         )
         .unwrap();
     let origin = -raster_rect.origin().to_f32();
@@ -787,7 +787,7 @@ pub fn rasterize_glyph_with_full_hinting() {
         size,
         Transform2F::from_translation(origin),
         HintingOptions::Full(size),
-        RasterizationOptions::GrayscaleAa,
+        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
     )
     .unwrap();
     check_L_shape(&canvas);
@@ -825,7 +825,7 @@ pub fn rasterize_glyph() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions::GrayscaleAa,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -835,7 +835,7 @@ pub fn rasterize_glyph() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions::GrayscaleAa,
+        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
     )
     .unwrap();
     check_curly_shape(&canvas);
@@ -855,7 +855,7 @@ pub fn rasterize_empty_glyph() {
         16.0,
         Transform2F::default(),
         HintingOptions::None,
-        RasterizationOptions::GrayscaleAa,
+        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
     )
     .unwrap();
 }
@@ -874,7 +874,7 @@ pub fn rasterize_empty_glyph_on_empty_canvas() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions::GrayscaleAa,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -884,7 +884,7 @@ pub fn rasterize_empty_glyph_on_empty_canvas() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions::GrayscaleAa,
+        RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::GrayscaleAa, use_thin_strokes: false },
     )
     .unwrap();
 }
@@ -905,7 +905,7 @@ pub fn font_transform() {
             size,
             Transform2F::from_translation(Vector2F::splat(8.0)),
             HintingOptions::None,
-            RasterizationOptions::Bilevel,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
         )
         .unwrap();
     let raster_rect2 = font
@@ -914,7 +914,7 @@ pub fn font_transform() {
             size,
             Transform2F::row_major(3.0, 0.0, 0.0, 3.0, 8.0, 8.0),
             HintingOptions::None,
-            RasterizationOptions::Bilevel,
+            RasterizationOptions { antialiasing_strategy: AntialiasingStrategy::Bilevel, use_thin_strokes: false },
         )
         .unwrap();
     assert!((raster_rect2.width() - raster_rect.width() * 3).abs() <= 3);


### PR DESCRIPTION
## Description

This PR changes `RasterizationOptions` to be a struct, instead of an enum representing what I am calling "antialiasing strategy".  By doing so, we can more easily add other options that affect glyph rendering, like `use_thin_strokes`, which I've added and wired up here.

Contributes to https://linear.app/warpdotdev/issue/WAR-1685/360-core-font-is-bolder-than-needed.

## Screenshot

Normal stroke thickness on top; thin strokes on bottom:

![image](https://user-images.githubusercontent.com/211194/173685876-377c0511-7f65-4fa7-8b91-973f44c84dd4.png)
