### PR TITLE
Revert "Add support for rendering glyphs using thin strokes. (#10)"

### DIFF
--- a/examples/render-glyph.rs
+++ b/examples/render-glyph.rs
@@ -15,7 +15,7 @@ extern crate pathfinder_geometry;
 
 use clap::{App, Arg, ArgGroup, ArgMatches};
 use colored::Colorize;
-use font_kit::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
+use font_kit::canvas::{Canvas, Format, RasterizationOptions};
 use font_kit::hinting::HintingOptions;
 use font_kit::source::SystemSource;
 use pathfinder_geometry::transform2d::Transform2F;
@@ -65,9 +65,6 @@ fn get_args() -> ArgMatches<'static> {
         .number_of_values(4);
     let rasterization_mode_group =
         ArgGroup::with_name("rasterization-mode").args(&["grayscale", "bilevel", "subpixel"]);
-    let thin_strokes_arg = Arg::with_name("use_thin_strokes")
-        .help("Use thin strokes when rasterizing glyphs")
-        .long("use_thin_strokes");
     App::new("render-glyph")
         .version("0.1")
         .author("The Pathfinder Project Developers")
@@ -79,7 +76,6 @@ fn get_args() -> ArgMatches<'static> {
         .arg(bilevel_arg)
         .arg(subpixel_arg)
         .group(rasterization_mode_group)
-        .arg(thin_strokes_arg)
         .arg(hinting_arg)
         .arg(transform_arg)
         .get_matches()
@@ -92,17 +88,12 @@ fn main() {
     let character = matches.value_of("GLYPH").unwrap().chars().next().unwrap();
     let size: f32 = matches.value_of("SIZE").unwrap().parse().unwrap();
 
-    let (canvas_format, antialiasing_strategy) = if matches.is_present("bilevel") {
-        (Format::A8, AntialiasingStrategy::Bilevel)
+    let (canvas_format, rasterization_options) = if matches.is_present("bilevel") {
+        (Format::A8, RasterizationOptions::Bilevel)
     } else if matches.is_present("subpixel") {
-        (Format::Rgb24, AntialiasingStrategy::SubpixelAa)
+        (Format::Rgb24, RasterizationOptions::SubpixelAa)
     } else {
-        (Format::A8, AntialiasingStrategy::GrayscaleAa)
-    };
-
-    let rasterization_options = RasterizationOptions {
-        antialiasing_strategy,
-        use_thin_strokes: matches.is_present("use_thin_strokes"),
+        (Format::A8, RasterizationOptions::GrayscaleAa)
     };
 
     let mut transform = Transform2F::default();

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -249,24 +249,13 @@ impl Format {
 
 /// The antialiasing strategy that should be used when rasterizing glyphs.
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub enum AntialiasingStrategy {
+pub enum RasterizationOptions {
     /// "Black-and-white" rendering. Each pixel is either entirely on or off.
     Bilevel,
     /// Grayscale antialiasing. Only one channel is used.
     GrayscaleAa,
     /// Subpixel RGB antialiasing, for LCD screens.
     SubpixelAa,
-}
-
-/// Options to control rasterization.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct RasterizationOptions {
-    /// The antialiasing strategy to use when rasterizing glyphs.
-    pub antialiasing_strategy: AntialiasingStrategy,
-
-    /// Whether or not to render glyphs with a thinner stroke.
-    /// Currently only supported for the core_text loader.
-    pub use_thin_strokes: bool,
 }
 
 trait Blit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //!     # extern crate font_kit;
 //!     # extern crate pathfinder_geometry;
 //!     #
-//!     use font_kit::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
+//!     use font_kit::canvas::{Canvas, Format, RasterizationOptions};
 //!     use font_kit::family_name::FamilyName;
 //!     use font_kit::hinting::HintingOptions;
 //!     use font_kit::properties::Properties;
@@ -37,10 +37,7 @@
 //!                          32.0,
 //!                          Transform2F::from_translation(Vector2F::new(0.0, 32.0)),
 //!                          HintingOptions::None,
-//!                          RasterizationOptions {
-//!                              antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-//!                              use_thin_strokes: false,
-//!                          })
+//!                          RasterizationOptions::GrayscaleAa)
 //!         .unwrap();
 //!
 //! ## Backends

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -17,7 +17,7 @@ use pathfinder_geometry::transform2d::Transform2F;
 use pathfinder_geometry::vector::Vector2F;
 use std::sync::Arc;
 
-use crate::canvas::{AntialiasingStrategy, Canvas, RasterizationOptions};
+use crate::canvas::{Canvas, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;

--- a/src/loaders/core_text.rs
+++ b/src/loaders/core_text.rs
@@ -37,7 +37,7 @@ use std::ops::Deref;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
+use crate::canvas::{Canvas, Format, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -550,22 +550,16 @@ impl Font {
         let core_graphics_size = CGSize::new(canvas.size.x() as f64, canvas.size.y() as f64);
         core_graphics_context.fill_rect(CGRect::new(&CG_ZERO_POINT, &core_graphics_size));
 
-        match rasterization_options.antialiasing_strategy {
-            AntialiasingStrategy::Bilevel => {
+        match rasterization_options {
+            RasterizationOptions::Bilevel => {
                 core_graphics_context.set_allows_font_smoothing(false);
                 core_graphics_context.set_should_smooth_fonts(false);
                 core_graphics_context.set_should_antialias(false);
             }
-            AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
+            RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
                 // FIXME(pcwalton): These shouldn't be handled the same!
-                if rasterization_options.use_thin_strokes {
-                    // Font smoothing produces thicker strokes; turning it off will lead to
-                    // thinner glyphs.
-                    core_graphics_context.set_should_smooth_fonts(false);
-                } else {
-                    core_graphics_context.set_should_smooth_fonts(true);
-                }
                 core_graphics_context.set_allows_font_smoothing(true);
+                core_graphics_context.set_should_smooth_fonts(true);
                 core_graphics_context.set_should_antialias(true);
             }
         }

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -45,7 +45,7 @@ use winapi::um::dwrite::DWRITE_READING_DIRECTION;
 use winapi::um::dwrite::DWRITE_READING_DIRECTION_LEFT_TO_RIGHT;
 use winapi::um::fileapi;
 
-use crate::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
+use crate::canvas::{Canvas, Format, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -463,9 +463,9 @@ impl Font {
             rasterization_options,
         )?;
 
-        let texture_type = match rasterization_options.antialiasing_strategy {
-            AntialiasingStrategy::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
-            AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
+        let texture_type = match rasterization_options {
+            RasterizationOptions::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
+            RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
                 DWRITE_TEXTURE_CLEARTYPE_3x1
             }
         };
@@ -509,9 +509,9 @@ impl Font {
             rasterization_options,
         )?;
 
-        let texture_type = match rasterization_options.antialiasing_strategy {
-            AntialiasingStrategy::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
-            AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
+        let texture_type = match rasterization_options {
+            RasterizationOptions::Bilevel => DWRITE_TEXTURE_ALIASED_1x1,
+            RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
                 DWRITE_TEXTURE_CLEARTYPE_3x1
             }
         };
@@ -597,9 +597,9 @@ impl Font {
                 bidiLevel: 0,
             };
 
-            let rendering_mode = match rasterization_options.antialiasing_strategy {
-                AntialiasingStrategy::Bilevel => DWRITE_RENDERING_MODE_ALIASED,
-                AntialiasingStrategy::GrayscaleAa | AntialiasingStrategy::SubpixelAa => {
+            let rendering_mode = match rasterization_options {
+                RasterizationOptions::Bilevel => DWRITE_RENDERING_MODE_ALIASED,
+                RasterizationOptions::GrayscaleAa | RasterizationOptions::SubpixelAa => {
                     DWRITE_RENDERING_MODE_NATURAL
                 }
             };

--- a/src/loaders/freetype.rs
+++ b/src/loaders/freetype.rs
@@ -42,7 +42,7 @@ use std::ptr;
 use std::slice;
 use std::sync::Arc;
 
-use crate::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
+use crate::canvas::{Canvas, Format, RasterizationOptions};
 use crate::error::{FontLoadingError, GlyphLoadingError};
 use crate::file_type::FileType;
 use crate::handle::Handle;
@@ -430,10 +430,7 @@ impl Font {
         S: OutlineSink,
     {
         unsafe {
-            let rasterization_options = RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-                use_thin_strokes: false,
-            };
+            let rasterization_options = RasterizationOptions::GrayscaleAa;
             let load_flags = self
                 .hinting_and_rasterization_options_to_load_flags(hinting, rasterization_options);
 
@@ -878,17 +875,17 @@ impl Font {
         hinting: HintingOptions,
         rasterization: RasterizationOptions,
     ) -> u32 {
-        let mut options = match (hinting, rasterization.antialiasing_strategy) {
-            (HintingOptions::VerticalSubpixel(_), _) | (_, AntialiasingStrategy::SubpixelAa) => {
+        let mut options = match (hinting, rasterization) {
+            (HintingOptions::VerticalSubpixel(_), _) | (_, RasterizationOptions::SubpixelAa) => {
                 FT_LOAD_TARGET_LCD
             }
             (HintingOptions::None, _) => FT_LOAD_TARGET_NORMAL | FT_LOAD_NO_HINTING,
-            (HintingOptions::Vertical(_), AntialiasingStrategy::Bilevel)
-            | (HintingOptions::Full(_), AntialiasingStrategy::Bilevel) => FT_LOAD_TARGET_MONO,
+            (HintingOptions::Vertical(_), RasterizationOptions::Bilevel)
+            | (HintingOptions::Full(_), RasterizationOptions::Bilevel) => FT_LOAD_TARGET_MONO,
             (HintingOptions::Vertical(_), _) => FT_LOAD_TARGET_LIGHT,
             (HintingOptions::Full(_), _) => FT_LOAD_TARGET_NORMAL,
         };
-        if rasterization.antialiasing_strategy == AntialiasingStrategy::Bilevel {
+        if rasterization == RasterizationOptions::Bilevel {
             options |= FT_LOAD_MONOCHROME
         }
         options

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -10,7 +10,7 @@
 
 // General tests.
 
-use font_kit::canvas::{AntialiasingStrategy, Canvas, Format, RasterizationOptions};
+use font_kit::canvas::{Canvas, Format, RasterizationOptions};
 use font_kit::family_name::FamilyName;
 use font_kit::file_type::FileType;
 use font_kit::font::Font;
@@ -453,10 +453,7 @@ pub fn get_glyph_raster_bounds() {
     let transform = Transform2F::default();
     let size = 32.0;
     let hinting_options = HintingOptions::None;
-    let rasterization_options = RasterizationOptions {
-        antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-        use_thin_strokes: false,
-    };
+    let rasterization_options = RasterizationOptions::GrayscaleAa;
     #[cfg(all(not(target_family = "windows")))]
     let expected_rect = RectI::new(Vector2I::new(1, -20), Vector2I::new(14, 21));
     #[cfg(target_family = "windows")]
@@ -668,10 +665,7 @@ pub fn rasterize_glyph_with_grayscale_aa() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::GrayscaleAa,
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -681,10 +675,7 @@ pub fn rasterize_glyph_with_grayscale_aa() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions {
-            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-            use_thin_strokes: false,
-        },
+        RasterizationOptions::GrayscaleAa,
     )
     .unwrap();
     check_L_shape(&canvas);
@@ -706,10 +697,7 @@ pub fn rasterize_glyph_bilevel() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::Bilevel,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::Bilevel,
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -719,10 +707,7 @@ pub fn rasterize_glyph_bilevel() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions {
-            antialiasing_strategy: AntialiasingStrategy::Bilevel,
-            use_thin_strokes: false,
-        },
+        RasterizationOptions::Bilevel,
     )
     .unwrap();
     assert!(canvas
@@ -748,10 +733,7 @@ pub fn rasterize_glyph_bilevel_offset() {
             size,
             Transform2F::from_translation(Vector2F::new(30.0, 100.0)),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::Bilevel,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::Bilevel,
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -761,10 +743,7 @@ pub fn rasterize_glyph_bilevel_offset() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32() + Vector2F::new(30.0, 100.0)),
         HintingOptions::None,
-        RasterizationOptions {
-            antialiasing_strategy: AntialiasingStrategy::Bilevel,
-            use_thin_strokes: false,
-        },
+        RasterizationOptions::Bilevel,
     )
     .unwrap();
 
@@ -797,10 +776,7 @@ pub fn rasterize_glyph_with_full_hinting() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::Bilevel,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::Bilevel,
         )
         .unwrap();
     let origin = -raster_rect.origin().to_f32();
@@ -811,10 +787,7 @@ pub fn rasterize_glyph_with_full_hinting() {
         size,
         Transform2F::from_translation(origin),
         HintingOptions::Full(size),
-        RasterizationOptions {
-            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-            use_thin_strokes: false,
-        },
+        RasterizationOptions::GrayscaleAa,
     )
     .unwrap();
     check_L_shape(&canvas);
@@ -852,10 +825,7 @@ pub fn rasterize_glyph() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::GrayscaleAa,
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -865,10 +835,7 @@ pub fn rasterize_glyph() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions {
-            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-            use_thin_strokes: false,
-        },
+        RasterizationOptions::GrayscaleAa,
     )
     .unwrap();
     check_curly_shape(&canvas);
@@ -888,10 +855,7 @@ pub fn rasterize_empty_glyph() {
         16.0,
         Transform2F::default(),
         HintingOptions::None,
-        RasterizationOptions {
-            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-            use_thin_strokes: false,
-        },
+        RasterizationOptions::GrayscaleAa,
     )
     .unwrap();
 }
@@ -910,10 +874,7 @@ pub fn rasterize_empty_glyph_on_empty_canvas() {
             size,
             Transform2F::default(),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::GrayscaleAa,
         )
         .unwrap();
     let mut canvas = Canvas::new(raster_rect.size(), Format::A8);
@@ -923,10 +884,7 @@ pub fn rasterize_empty_glyph_on_empty_canvas() {
         size,
         Transform2F::from_translation(-raster_rect.origin().to_f32()),
         HintingOptions::None,
-        RasterizationOptions {
-            antialiasing_strategy: AntialiasingStrategy::GrayscaleAa,
-            use_thin_strokes: false,
-        },
+        RasterizationOptions::GrayscaleAa,
     )
     .unwrap();
 }
@@ -947,10 +905,7 @@ pub fn font_transform() {
             size,
             Transform2F::from_translation(Vector2F::splat(8.0)),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::Bilevel,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::Bilevel,
         )
         .unwrap();
     let raster_rect2 = font
@@ -959,10 +914,7 @@ pub fn font_transform() {
             size,
             Transform2F::row_major(3.0, 0.0, 0.0, 3.0, 8.0, 8.0),
             HintingOptions::None,
-            RasterizationOptions {
-                antialiasing_strategy: AntialiasingStrategy::Bilevel,
-                use_thin_strokes: false,
-            },
+            RasterizationOptions::Bilevel,
         )
         .unwrap();
     assert!((raster_rect2.width() - raster_rect.width() * 3).abs() <= 3);


### PR DESCRIPTION
This reverts commit efe122c90727526b9c6dd522b733e66bf0e26454.