### PR TITLE
Bump core-graphics to 0.25.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ features = ["dwrite", "minwindef", "sysinfoapi", "winbase", "winnt"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 core-foundation = "0.10.0"
-core-graphics = "0.24.0"
+core-graphics = "0.25.0"
 core-text = "21.0.0"
 
 [target.'cfg(not(any(target_family = "windows", target_os = "macos", target_os = "ios")))'.dependencies]


### PR DESCRIPTION
Fixes version skew issues when trying to use the latest version of the `core-text` crate.