### PR TITLE
Avoid panics when calling into `dwrote` (#260)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ pbr = "1.0"
 prettytable-rs = "0.10"
 
 [target.'cfg(target_family = "windows")'.dependencies]
-dwrote = { version = "0.11", default-features = false }
+dwrote = { version = "^0.11.3", default-features = false }
 
 [target.'cfg(target_family = "windows")'.dependencies.winapi]
 version = "0.3"

--- a/src/loaders/directwrite.rs
+++ b/src/loaders/directwrite.rs
@@ -107,7 +107,9 @@ impl Font {
                     font_index -= 1;
                     continue;
                 }
-                let dwrite_font = family.get_font(family_font_index);
+                let Ok(dwrite_font) = family.font(family_font_index) else {
+                    continue;
+                };
                 let dwrite_font_face = dwrite_font.create_font_face();
                 return Ok(Font {
                     dwrite_font,

--- a/src/sources/directwrite.rs
+++ b/src/sources/directwrite.rs
@@ -41,7 +41,9 @@ impl DirectWriteSource {
 
         for dwrite_family in self.system_font_collection.families_iter() {
             for font_index in 0..dwrite_family.get_font_count() {
-                let dwrite_font = dwrite_family.get_font(font_index);
+                let Ok(dwrite_font) = dwrite_family.font(font_index) else {
+                    continue;
+                };
                 handles.push(self.create_handle_from_dwrite_font(dwrite_font))
             }
         }
@@ -54,7 +56,7 @@ impl DirectWriteSource {
         Ok(self
             .system_font_collection
             .families_iter()
-            .map(|dwrite_family| dwrite_family.name())
+            .filter_map(|dwrite_family| dwrite_family.family_name().ok())
             .collect())
     }
 
@@ -63,16 +65,15 @@ impl DirectWriteSource {
     /// TODO(pcwalton): Case-insensitivity.
     pub fn select_family_by_name(&self, family_name: &str) -> Result<FamilyHandle, SelectionError> {
         let mut family = FamilyHandle::new();
-        let dwrite_family = match self
-            .system_font_collection
-            .get_font_family_by_name(family_name)
-        {
-            Some(dwrite_family) => dwrite_family,
-            None => return Err(SelectionError::NotFound),
+        let dwrite_family = match self.system_font_collection.font_family_by_name(family_name) {
+            Ok(Some(dwrite_family)) => dwrite_family,
+            Err(_) | Ok(None) => return Err(SelectionError::NotFound),
         };
         for font_index in 0..dwrite_family.get_font_count() {
-            let dwrite_font = dwrite_family.get_font(font_index);
-            family.push(self.create_handle_from_dwrite_font(dwrite_font))
+            let Ok(dwrite_font) = dwrite_family.font(font_index) else {
+                continue;
+            };
+            family.push(self.create_handle_from_dwrite_font(dwrite_font));
         }
         Ok(family)
     }


### PR DESCRIPTION
This PR cherry-picks one of my commits upstream servo/font-kit/pull/260

It addresses this panic: https://warpdotdev.sentry.io/issues/6272857249/?project=5658526&referrer=Linear